### PR TITLE
(5-3)featur/パスワード暗号orハッシュ化

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,13 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-security -->
+		<dependency>
+    		<groupId>org.springframework.boot</groupId>
+    		<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		
+		
 	</dependencies>
 
 	<build>

--- a/src/main/java/jp/co/sample/emp_management/config/WebSecurityConfig.java
+++ b/src/main/java/jp/co/sample/emp_management/config/WebSecurityConfig.java
@@ -1,0 +1,27 @@
+package jp.co.sample.emp_management.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+@EnableWebSecurity
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        //ログインページを指定。
+        //ログインページへのアクセスは全員許可する。
+
+        http.authorizeRequests()
+            .anyRequest().permitAll();
+    }
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
+++ b/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
@@ -5,6 +5,7 @@ import javax.servlet.http.HttpSession;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DuplicateKeyException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -32,6 +33,9 @@ public class AdministratorController {
 	
 	@Autowired
 	private HttpSession session;
+	
+	@Autowired
+	PasswordEncoder passwordEncoder;
 
 	
 	/**
@@ -122,6 +126,7 @@ public class AdministratorController {
 	 */
 	@RequestMapping("/login")
 	public String login(LoginForm form, BindingResult result, Model model) {
+		
 		Administrator administrator = administratorService.login(form.getMailAddress(), form.getPassword());
 		if (administrator == null) {
 			model.addAttribute("errorMessage", "メールアドレスまたはパスワードが不正です。");

--- a/src/main/java/jp/co/sample/emp_management/service/AdministratorService.java
+++ b/src/main/java/jp/co/sample/emp_management/service/AdministratorService.java
@@ -1,6 +1,7 @@
 package jp.co.sample.emp_management.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,12 +21,16 @@ public class AdministratorService {
 	@Autowired
 	private AdministratorRepository administratorRepository;
 
+	@Autowired
+	PasswordEncoder passwordEncoder;
 	/**
 	 * 管理者情報を登録します.
 	 * 
 	 * @param administrator 管理者情報
 	 */
 	public void insert(Administrator administrator) {
+		
+		administrator.setPassword(passwordEncoder.encode(administrator.getPassword()));
 		administratorRepository.insert(administrator);
 	}
 	
@@ -36,7 +41,11 @@ public class AdministratorService {
 	 * @return 管理者情報　存在しない場合はnullが返ります
 	 */
 	public Administrator login(String mailAddress, String password) {
-		Administrator administrator = administratorRepository.findByMailAddressAndPassward(mailAddress, password);
-		return administrator;
+		
+		Administrator administrator = administratorRepository.findByMailAddress(mailAddress);
+		if(passwordEncoder.matches(password, administrator.getPassword())) {
+			return administrator;
+		}
+		return null;
 	}
 }


### PR DESCRIPTION
パスワードのハッシュ化とハッシュとの認証の実装をしました。
AdministratorRepositoryのFindByEmailAndPassWordメソッドはログインでは不要になったため他の用途が無ければ削除しても良いかもしれません。